### PR TITLE
[REM] oca_dependencies: clean file T#77342

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,6 +1,0 @@
-project-reporting
-sale-workflow
-server-tools
-timesheet
-account-budgeting
-web


### PR DESCRIPTION
This is causing to clone too many unnecessary modules.

Since this is an unsupported version used by only one customer (which is about to migrate anyway), this seems to be the cleanest solution.